### PR TITLE
Correct fast_evaluation argument in wrapper

### DIFF
--- a/oxipng.pyi
+++ b/oxipng.pyi
@@ -190,7 +190,7 @@ class RawImage:
         scale_16: bool = False,
         strip: StripChunks = StripChunks.none(),
         deflate: Deflaters = Deflaters.libdeflater(11),
-        use_heuristics: bool = False,
+        fast_evaluation: bool = False,
         timeout: Optional[int] = None,
     ) -> bytes:
         """
@@ -218,7 +218,7 @@ def optimize(
     scale_16: bool = False,
     strip: StripChunks = StripChunks.none(),
     deflate: Deflaters = Deflaters.libdeflater(11),
-    use_heuristics: bool = False,
+    fast_evaluation: bool = False,
     timeout: Optional[int] = None,
 ) -> None:
     """
@@ -245,7 +245,7 @@ def optimize_from_memory(
     scale_16: bool = False,
     strip: StripChunks = StripChunks.none(),
     deflate: Deflaters = Deflaters.libdeflater(11),
-    use_heuristics: bool = False,
+    fast_evaluation: bool = False,
     timeout: Optional[int] = None,
 ) -> bytes:
     """


### PR DESCRIPTION
In the Rust code, the option is named `fast_evaluation`. However, in the Python wrapper, the helper methods use a different name, `use_heuristics`, which is not mentioned in the README documentation. Since this is not the name that appears in the documentations and consumers of the current API use the `fast_evaluation`, we should rename the option in the Python wrapper to ensure consistency and compatibility between the two layers.